### PR TITLE
Implement new token exchange

### DIFF
--- a/Polyglot/Polyglot.swift
+++ b/Polyglot/Polyglot.swift
@@ -151,7 +151,7 @@ open class Polyglot {
             }
             let toLanguageComponent = "&to=\(self.toLanguage.rawValue.urlEncoded!)"
             let fromLanguageComponent = (self.fromLanguage != nil) ? "&from=\(self.fromLanguage!.rawValue.urlEncoded!)" : ""
-            let urlString = "http://api.microsofttranslator.com/v2/Http.svc/Translate?text=\(text.urlEncoded!)\(toLanguageComponent)\(fromLanguageComponent)"
+            let urlString = "https://api.microsofttranslator.com/v2/Http.svc/Translate?text=\(text.urlEncoded!)\(toLanguageComponent)\(fromLanguageComponent)"
 
             var request = URLRequest(url: URL(string: urlString)!)
             request.httpMethod = "GET"
@@ -161,7 +161,7 @@ open class Polyglot {
                 let translation: String
                 guard
                     let data = data,
-                    let xmlString = NSString(data: data, encoding: String.Encoding.utf8.rawValue) as? String
+                    let xmlString = String.init(data: data, encoding: .utf8)
                 else {
                     translation = ""
                     return

--- a/Polyglot/Session.swift
+++ b/Polyglot/Session.swift
@@ -37,29 +37,30 @@ class Session {
 
     func getAccessToken(_ callback: @escaping ((_ token: String) -> (Void))) {
         if (accessToken == nil || isExpired) {
-            let url = URL(string: "https://datamarket.accesscontrol.windows.net/v2/OAuth2-13")
+            let url = URL(string: "https://api.cognitive.microsoft.com/sts/v1.0/issueToken")
 
             var request = URLRequest(url: url!)
             request.httpMethod = "POST"
-
-            let bodyString = "client_id=\(clientId.urlEncoded!)&client_secret=\(clientSecret.urlEncoded!)&scope=http://api.microsofttranslator.com&grant_type=client_credentials"
-            request.httpBody = bodyString.data(using: String.Encoding.utf8)
+            request.addValue(clientSecret, forHTTPHeaderField: "Ocp-Apim-Subscription-Key")
 
             let task = URLSession.shared.dataTask(with: request, completionHandler: {(data, response, error) in
                 guard
                     let data = data,
-                let resultsDict = try? JSONSerialization.jsonObject(with: data, options: JSONSerialization.ReadingOptions.mutableContainers) as? [String: Any],
-                    let expiresIn = resultsDict?["expires_in"] as? NSString
+                    let token = String(data: data, encoding: String.Encoding.utf8)
                 else {
                     callback("")
                     return
                 }
-                self.expirationTime = Date(timeIntervalSinceNow: expiresIn.doubleValue)
+                
+                // API only returns JSON when there's a error
+                if let _ = try? JSONSerialization.jsonObject(with: data, options: JSONSerialization.ReadingOptions.mutableContainers) as? [String: Any] {
+                    callback("")
+                } else {
+                    self.expirationTime = Date(timeIntervalSinceNow: 600)
+                    self.accessToken = token
+                    callback(token)
+                }
 
-                let token = resultsDict?["access_token"] as! String
-                self.accessToken = token
-
-                callback(token)
             }) 
 
             task.resume()


### PR DESCRIPTION
Translations weren't working for me anymore. After some digging I found out that
datamarket.accesscontrol.windows.net has been deprecated in favour of api.cognitive.microsoft.com.

I updated Session.swift to use the new token exchange implementation.

More information: http://docs.microsofttranslator.com/oauth-token.html

**Note:** Because PolyglotSample and PolyglotTests haven't been converted to swift 3 I wasn't able to compile directly from those.